### PR TITLE
Always run all optimizers

### DIFF
--- a/src/ImageOptimizer/OptimizerFactory.php
+++ b/src/ImageOptimizer/OptimizerFactory.php
@@ -95,7 +95,7 @@ class OptimizerFactory
         $this->optimizers['jpeg'] = $this->optimizers['jpg'] = new ChainOptimizer(array(
             $this->unwrap($this->optimizers['jpegtran']),
             $this->unwrap($this->optimizers['jpegoptim']),
-        ), true);
+        ));
 
         $this->optimizers[self::OPTIMIZER_SMART] = $this->wrap(new SmartOptimizer(array(
             TypeGuesser::TYPE_GIF => $this->optimizers['gif'],


### PR DESCRIPTION
With the option to pass arguments to optimizers (#7) the second
optimizer may optimize the image more and should not be skipped.
