### PR TITLE
Bug fix for Windows (Fix Issue #9)

### DIFF
--- a/src/ImageOptimizer/Command.php
+++ b/src/ImageOptimizer/Command.php
@@ -27,7 +27,11 @@ final class Command
         $args = array_merge($this->args, $customArgs);
 
         $suppressOutput = (defined('PHP_WINDOWS_VERSION_BUILD') ? '' : ' 1> /dev/null 2> /dev/null');
-        $command = escapeshellcmd($this->cmd).' '.implode(' ', array_map('escapeshellarg', $args)).$suppressOutput;
+        if(empty($suppressOutput)) {
+            $command = escapeshellarg($this->cmd).' '.implode(' ', array_map('escapeshellarg', $args)).$suppressOutput;
+        } else {
+            $command = escapeshellcmd($this->cmd).' '.implode(' ', array_map('escapeshellarg', $args)).$suppressOutput;
+        }
         exec($command, $output, $result);
 
         if($result == 127) {


### PR DESCRIPTION
Bugfix for Windows where control characters(^) are automatically added to command. Fixes Issue #9.