### PR TITLE
Document breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,8 @@ CHANGELOG
     * execute only first successful optimizer by default (new options: `execute_only_first_png_optimizer` and `execute_only_first_jpeg_optimizer`)
     * ignore error when first optimizer fails, but second one succeeds
     * report an error when all optimizers fail (an error is ignored when `ignore_errors` is enabled)
+    * BC break - `ChainOptimizer` constructor now requires 2nd parameter, and adds 3rd parameter logger:
+```diff    
+-    public function __construct(array $optimizers, $executeFirst = false)
++    public function __construct(array $optimizers, $executeFirst, LoggerInterface $logger)
+```


### PR DESCRIPTION
This change is breaking and should be added to changelog.

I also suggest keeping backward compatibility, constructor can look like:

```php
public function __construct(array $optimizers, $executeFirst = false, LoggerInterface $logger = null)
```

Which would not break all project that depends on this package.
I upgraded `(1.0.6 => 1.1.2)` and errors started popping.