### PR TITLE
Bump psr/log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "symfony/process": "~2.0 | ~3.0 | ~4.0",
         "symfony/options-resolver": "~2.1 | ~3.0 | ~4.0",
-        "psr/log": "1.0.*"
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0"


### PR DESCRIPTION
I've got a similar problem to #59.
Composer fails to install a big project due to some dependency conflict in this package.

Composer only shows a cryptic message exactly like in the issue instead of providing precise information, however, experimentally I was able to trace it to `psr/log` version. php-fig/log v1.1.0 has been released recently and this breaks all of our builds.

There are no BCs between 1.0 and 1.1 so this should be totally safe to bump.