### PR TITLE
Fixed the bug that the copied files were not deleted when the optimization failed

### DIFF
--- a/src/ImageOptimizer/ChangedOutputOptimizer.php
+++ b/src/ImageOptimizer/ChangedOutputOptimizer.php
@@ -23,12 +23,22 @@ class ChangedOutputOptimizer implements WrapperOptimizer
             $this->outputPattern
         );
 
-        if($outputFilepath !== $filepath) {
+        $outputChanaged = $outputFilepath !== $filepath;
+
+        if ($outputChanaged) {
             copy($filepath, $outputFilepath);
             $filepath = $outputFilepath;
         }
 
-        $this->optimizer->optimize($filepath);
+        try {
+            $this->optimizer->optimize($filepath);
+        } catch (\Throwable $exception) {
+            if ($outputChanaged) {
+                unlink($filepath);
+            }
+
+            throw $exception;
+        }
     }
 
     public function unwrap(): Optimizer

--- a/src/ImageOptimizer/OptimizerFactory.php
+++ b/src/ImageOptimizer/OptimizerFactory.php
@@ -135,10 +135,10 @@ class OptimizerFactory
         }
 
         $this->optimizers[self::OPTIMIZER_SMART] = $this->wrap(new SmartOptimizer([
-            TypeGuesser::TYPE_GIF => $this->optimizers['gif'],
-            TypeGuesser::TYPE_PNG => $this->optimizers['png'],
-            TypeGuesser::TYPE_JPEG => $this->optimizers['jpeg'],
-            TypeGuesser::TYPE_SVG => $this->optimizers['svg']
+            TypeGuesser::TYPE_GIF => $this->unwrap($this->optimizers['gif']),
+            TypeGuesser::TYPE_PNG => $this->unwrap($this->optimizers['png']),
+            TypeGuesser::TYPE_JPEG => $this->unwrap($this->optimizers['jpeg']),
+            TypeGuesser::TYPE_SVG => $this->unwrap($this->optimizers['svg'])
         ]));
     }
 

--- a/tests/ImageOptimizer/OptimizersTest.php
+++ b/tests/ImageOptimizer/OptimizersTest.php
@@ -121,6 +121,38 @@ class OptimizersTest extends TestCase
         ;
     }
 
+    /**
+     * @test
+     */
+    public function optimizerFailed_optimizeChangedOutputFileWillBeDeleted()
+    {
+        $factory = new OptimizerFactory([
+            'output_filepath_pattern' => '%basename%/%filename%-optimized%ext%',
+            'optipng_bin' => '/dir/does/not/exist/bin',
+            'pngquant_bin' => '/dir/does/not/exist/bin',
+            'pngcrush_bin' => '/dir/does/not/exist/bin',
+            'pngout_bin' => '/dir/does/not/exist/bin',
+            'advpng_bin' => '/dir/does/not/exist/bin',
+            'gifsicle_bin' => '/dir/does/not/exist/bin',
+            'jpegoptim_bin' => '/dir/does/not/exist/bin',
+            'jpegtran_bin' => '/dir/does/not/exist/bin',
+            'svgo_bin' => '/dir/does/not/exist/bin',
+        ]);
+
+        $optimizer = $factory->get('jpg');
+
+        $sampleFile = $this->prepareSampleFile(__DIR__.'/Resources/sample.jpg');
+
+        $optimizer->optimize($sampleFile);
+
+        $this->assertFileNotExists(__DIR__.'/Resources/'.self::TMP_DIR.'/sample-optimized.jpg');
+
+        // smart optimizer will delete the file if it fails
+        $optimizer = $factory->get();
+        $optimizer->optimize($sampleFile);
+        $this->assertFileNotExists(__DIR__.'/Resources/'.self::TMP_DIR.'/sample-optimized.jpg');
+    }
+
     protected function tearDown(): void
     {
         foreach(['sample.gif', 'sample.jpg', 'sample.png', 'samplepng', 'sample.svg', 'sample-optimized.jpg'] as $file) {
@@ -137,4 +169,4 @@ class OptimizersTest extends TestCase
 
         return $destination;
     }
-} 
+}


### PR DESCRIPTION
When configured `output_filepath_pattern` which changed output path, the optimizer copied the file but doesn't deleted it when optimize failed.

today I create a demo with the following code: 

```php
require __DIR__ . '/vendor/autoload.php';

$factory = new \ImageOptimizer\OptimizerFactory([
    'output_filepath_pattern' => '%basename%/%filename%_optimized%ext%',
]);
$optimizer = $factory->get();

$filepath = __DIR__ . '/1.png';

$optimizer->optimize($filepath);
```

it copied two files: 

```
.
├── 1.png
├── 1_optimized.png
├── 1_optimized_optimized.png
```

[![Build Status](https://app.travis-ci.com/overtrue-forks/image-optimizer.svg?branch=master)](https://app.travis-ci.com/overtrue-forks/image-optimizer)

Thanks.