### PR TITLE
Added support for symfony process 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require": {
         "php": "^7.3 | ^8.0",
-        "symfony/process": "~3.3 | ~4.0 | ~5.0",
-        "symfony/options-resolver": "~3.3 | ~4.0 | ~5.0",
+        "symfony/process": "~3.3 | ~4.0 | ~5.0 | ~6.0",
+        "symfony/options-resolver": "~3.3 | ~4.0 | ~5.0 | ~6.0",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
I've updated the composer.json to permit symfony 6 components. 

I used the Vagrant environment to run the tests using php8.0 with the symfony 6 components and everything passed fine.

If theres anything i've missed, let me know.