### PR TITLE
Make compatible with PSR-12 formatting standard

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset name="PSR12 Coding Standards">
+    <description>A custom set of code standard rules</description>
+
+    <rule ref="PSR12"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+
+    <exclude-pattern>*\.(?!php$)</exclude-pattern>
+    <exclude-pattern>vendor/*</exclude-pattern>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,15 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "squizlabs/php_codesniffer": "^3.6"
+    },
+    "scripts": {
+        "phpcs":  "vendor/bin/phpcs  -s --standard=./.phpcs.xml ./",
+        "phpcbf": "vendor/bin/phpcbf --standard=./.phpcs.xml ./",
+        "test": [
+            "composer validate --strict",
+            "@phpcs"
+        ]
     }
 }

--- a/src/ImageOptimizer/ChainOptimizer.php
+++ b/src/ImageOptimizer/ChainOptimizer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
@@ -25,18 +26,23 @@ class ChainOptimizer implements Optimizer
     public function optimize(string $filepath): void
     {
         $exceptions = [];
-        foreach($this->optimizers as $optimizer) {
+        foreach ($this->optimizers as $optimizer) {
             try {
                 $optimizer->optimize($filepath);
 
-                if($this->executeFirst) break;
+                if ($this->executeFirst) {
+                    break;
+                }
             } catch (Exception $e) {
-                $this->logger->error('Error during image optimization. See exception for more details.', [ 'exception' => $e ]);
+                $this->logger->error(
+                    'Error during image optimization. See exception for more details.',
+                    ['exception' => $e]
+                );
                 $exceptions[] = $e;
             }
         }
 
-        if(count($exceptions) === count($this->optimizers)) {
+        if (count($exceptions) === count($this->optimizers)) {
             throw new Exception(sprintf('All optimizers failed to optimize the file: %s', $filepath));
         }
     }

--- a/src/ImageOptimizer/ChangedOutputOptimizer.php
+++ b/src/ImageOptimizer/ChangedOutputOptimizer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
@@ -19,7 +20,11 @@ class ChangedOutputOptimizer implements WrapperOptimizer
         $fileInfo = pathinfo($filepath);
         $outputFilepath = str_replace(
             ['%basename%', '%filename%', '%ext%'],
-            [$fileInfo['dirname'], $fileInfo['filename'], isset($fileInfo['extension']) ? '.'.$fileInfo['extension'] : ''],
+            [
+                $fileInfo['dirname'],
+                $fileInfo['filename'],
+                isset($fileInfo['extension']) ? '.' . $fileInfo['extension'] : ''
+            ],
             $this->outputPattern
         );
 

--- a/src/ImageOptimizer/Command.php
+++ b/src/ImageOptimizer/Command.php
@@ -1,9 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
 
-use function function_exists;
 use ImageOptimizer\Exception\CommandNotFound;
 use ImageOptimizer\Exception\Exception;
 use Symfony\Component\Process\Exception\RuntimeException;
@@ -17,12 +17,18 @@ final class Command
 
     public function __construct(string $bin, array $args = [], ?float $timeout = null)
     {
-        if(!function_exists('exec')) {
-            throw new Exception('"exec" function is not available. Please check if it is not listed as "disable_functions" in your "php.ini" file.');
+        if (!function_exists('exec')) {
+            throw new Exception(
+                '"exec" function is not available. ' .
+                'Please check if it is not listed as "disable_functions" in your "php.ini" file.'
+            );
         }
 
-        if(!function_exists('proc_open')) {
-            throw new RuntimeException('"proc_open" function is not available. Please check if it is not listed as "disable_functions" in your "php.ini" file.');
+        if (!function_exists('proc_open')) {
+            throw new RuntimeException(
+                '"proc_open" function is not available. ' .
+                'Please check if it is not listed as "disable_functions" in your "php.ini" file.'
+            );
         }
 
         $this->cmd = $bin;
@@ -38,16 +44,23 @@ final class Command
         try {
             $exitCode = $process->run();
             $commandLine = $process->getCommandLine();
-            $output = $process->getOutput().PHP_EOL.$process->getErrorOutput();
+            $output = $process->getOutput() . PHP_EOL . $process->getErrorOutput();
 
-            if($exitCode == 127) {
+            if ($exitCode == 127) {
                 throw new CommandNotFound(sprintf('Command "%s" not found.', $this->cmd));
             }
 
-            if($exitCode !== 0 || stripos($output, 'error') !== false || stripos($output, 'permission') !== false) {
-                throw new Exception(sprintf('Command failed, return code: %d, command: %s, stderr: %s', $exitCode, $commandLine, trim($output)));
+            if ($exitCode !== 0 || stripos($output, 'error') !== false || stripos($output, 'permission') !== false) {
+                throw new Exception(
+                    sprintf(
+                        'Command failed, return code: %d, command: %s, stderr: %s',
+                        $exitCode,
+                        $commandLine,
+                        trim($output)
+                    )
+                );
             }
-        } catch(RuntimeException $e) {
+        } catch (RuntimeException $e) {
             throw new Exception($e->getMessage(), $e->getCode(), $e);
         }
     }

--- a/src/ImageOptimizer/CommandOptimizer.php
+++ b/src/ImageOptimizer/CommandOptimizer.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
-
 
 class CommandOptimizer implements Optimizer
 {
@@ -19,7 +19,7 @@ class CommandOptimizer implements Optimizer
     {
         $customArgs = [$filepath];
 
-        if($this->extraArgs) {
+        if ($this->extraArgs) {
             $customArgs = array_merge(
                 is_callable($this->extraArgs) ? call_user_func($this->extraArgs, $filepath) : $this->extraArgs,
                 $customArgs

--- a/src/ImageOptimizer/Exception/CommandNotFound.php
+++ b/src/ImageOptimizer/Exception/CommandNotFound.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\Exception;

--- a/src/ImageOptimizer/Exception/Exception.php
+++ b/src/ImageOptimizer/Exception/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\Exception;

--- a/src/ImageOptimizer/Optimizer.php
+++ b/src/ImageOptimizer/Optimizer.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
-
 
 use ImageOptimizer\Exception\Exception;
 
@@ -14,4 +14,4 @@ interface Optimizer
      * @throws Exception
      */
     public function optimize(string $filepath): void;
-} 
+}

--- a/src/ImageOptimizer/OptimizerFactory.php
+++ b/src/ImageOptimizer/OptimizerFactory.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
-
 
 use ImageOptimizer\Exception\Exception;
 use ImageOptimizer\TypeGuesser\TypeGuesser;
@@ -13,7 +13,7 @@ use Symfony\Component\Process\ExecutableFinder;
 
 class OptimizerFactory
 {
-    const OPTIMIZER_SMART = 'smart';
+    public const OPTIMIZER_SMART = 'smart';
 
     private $optimizers = [];
     private $options;
@@ -78,10 +78,12 @@ class OptimizerFactory
             $this->commandOptimizer('optipng', $this->options['optipng_options'])
         );
         $this->optimizers['pngquant'] = $this->wrap(
-            $this->commandOptimizer('pngquant', $this->options['pngquant_options'],
-                function($filepath){
+            $this->commandOptimizer(
+                'pngquant',
+                $this->options['pngquant_options'],
+                function ($filepath) {
                     $ext = pathinfo($filepath, PATHINFO_EXTENSION);
-                    return ['--ext='.($ext ? '.'.$ext : ''), '--'];
+                    return ['--ext=' . ($ext ? '.' . $ext : ''), '--'];
                 }
             )
         );
@@ -109,7 +111,9 @@ class OptimizerFactory
             $this->commandOptimizer('jpegoptim', $this->options['jpegoptim_options'])
         );
         $this->optimizers['jpegtran'] = $this->wrap(
-            $this->commandOptimizer('jpegtran', $this->options['jpegtran_options'],
+            $this->commandOptimizer(
+                'jpegtran',
+                $this->options['jpegtran_options'],
                 function ($filepath) {
                     return ['-outfile', $filepath];
                 }
@@ -121,14 +125,16 @@ class OptimizerFactory
         ], $this->options['execute_only_first_jpeg_optimizer'], $this->logger));
 
         $this->optimizers['svg'] = $this->optimizers['svgo'] = $this->wrap(
-            $this->commandOptimizer('svgo', $this->options['svgo_options'],
+            $this->commandOptimizer(
+                'svgo',
+                $this->options['svgo_options'],
                 function ($filepath) {
                     return ['--input' => $filepath, '--output' => $filepath];
                 }
             )
         );
 
-        foreach($this->options['custom_optimizers'] as $key => $options) {
+        foreach ($this->options['custom_optimizers'] as $key => $options) {
             $this->optimizers[$key] = $this->wrap(
                 $this->commandOptimizer($options['command'], isset($options['args']) ? $options['args'] : [])
             );
@@ -152,8 +158,16 @@ class OptimizerFactory
 
     private function wrap(Optimizer $optimizer): Optimizer
     {
-        $optimizer = $optimizer instanceof ChangedOutputOptimizer ? $optimizer : new ChangedOutputOptimizer($this->option('output_filepath_pattern'), $optimizer);
-        return $this->option('ignore_errors', true) ? new SuppressErrorOptimizer($optimizer, $this->logger) : $optimizer;
+        $optimizer = $optimizer instanceof ChangedOutputOptimizer ?
+            $optimizer :
+            new ChangedOutputOptimizer(
+                $this->option('output_filepath_pattern'),
+                $optimizer
+            );
+
+        return $this->option('ignore_errors', true) ?
+            new SuppressErrorOptimizer($optimizer, $this->logger) :
+            $optimizer;
     }
 
     private function unwrap(Optimizer $optimizer): Optimizer
@@ -164,7 +178,7 @@ class OptimizerFactory
     private function executable(string $name): string
     {
         $executableFinder = $this->executableFinder;
-        return $this->option($name.'_bin', function() use($name, $executableFinder){
+        return $this->option($name . '_bin', function () use ($name, $executableFinder) {
             return $executableFinder->find($name, $name);
         });
     }
@@ -181,7 +195,7 @@ class OptimizerFactory
      */
     public function get(string $name = self::OPTIMIZER_SMART): Optimizer
     {
-        if(!isset($this->optimizers[$name])) {
+        if (!isset($this->optimizers[$name])) {
             throw new Exception(sprintf('Optimizer "%s" not found', $name));
         }
 

--- a/src/ImageOptimizer/SmartOptimizer.php
+++ b/src/ImageOptimizer/SmartOptimizer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
@@ -25,7 +26,7 @@ class SmartOptimizer implements Optimizer
     {
         $type = $this->typeGuesser->guess($filepath);
 
-        if(!isset($this->optimizers[$type])) {
+        if (!isset($this->optimizers[$type])) {
             throw new Exception(sprintf('Optimizer for type "%s" not found.', $type));
         }
 

--- a/src/ImageOptimizer/SuppressErrorOptimizer.php
+++ b/src/ImageOptimizer/SuppressErrorOptimizer.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
-
 
 use ImageOptimizer\Exception\Exception;
 use Psr\Log\LoggerInterface;
@@ -23,7 +23,10 @@ class SuppressErrorOptimizer implements WrapperOptimizer
         try {
             $this->optimizer->optimize($filepath);
         } catch (Exception $e) {
-            $this->logger->error('Error during image optimization. See exception for more details.', [ 'exception' => $e ]);
+            $this->logger->error(
+                'Error during image optimization. See exception for more details.',
+                ['exception' => $e]
+            );
         }
     }
 

--- a/src/ImageOptimizer/TypeGuesser/ExtensionTypeGuesser.php
+++ b/src/ImageOptimizer/TypeGuesser/ExtensionTypeGuesser.php
@@ -1,12 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
 
-
 class ExtensionTypeGuesser implements TypeGuesser
 {
-
     /**
      * @param string $filepath
      * @return string Image file type, value of one of the TYPE_* const
@@ -15,7 +14,7 @@ class ExtensionTypeGuesser implements TypeGuesser
     {
         $ext = strtolower(pathinfo($filepath, PATHINFO_EXTENSION));
 
-        switch($ext) {
+        switch ($ext) {
             case 'png':
                 return self::TYPE_PNG;
             case 'gif':

--- a/src/ImageOptimizer/TypeGuesser/GdTypeGuesser.php
+++ b/src/ImageOptimizer/TypeGuesser/GdTypeGuesser.php
@@ -1,14 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
-
 
 class GdTypeGuesser implements TypeGuesser
 {
     public function __construct()
     {
-        if(!function_exists('gd_info')) {
+        if (!function_exists('gd_info')) {
             throw new \RuntimeException(sprintf('%s class require gd extension to be enabled', __CLASS__));
         }
     }
@@ -17,7 +17,7 @@ class GdTypeGuesser implements TypeGuesser
     {
         list(,,$type) = getimagesize($filepath);
 
-        switch($type) {
+        switch ($type) {
             case \IMAGETYPE_PNG:
                 return self::TYPE_PNG;
             case \IMAGETYPE_GIF:

--- a/src/ImageOptimizer/TypeGuesser/SmartTypeGuesser.php
+++ b/src/ImageOptimizer/TypeGuesser/SmartTypeGuesser.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
-
 
 class SmartTypeGuesser implements TypeGuesser
 {
@@ -23,10 +23,10 @@ class SmartTypeGuesser implements TypeGuesser
 
     public function guess(string $filepath): string
     {
-        foreach($this->typeGuessers as $typeGuesser) {
+        foreach ($this->typeGuessers as $typeGuesser) {
             $type = $typeGuesser->guess($filepath);
 
-            if($type !== self::TYPE_UNKNOWN) {
+            if ($type !== self::TYPE_UNKNOWN) {
                 return $type;
             }
         }

--- a/src/ImageOptimizer/TypeGuesser/TypeGuesser.php
+++ b/src/ImageOptimizer/TypeGuesser/TypeGuesser.php
@@ -1,19 +1,20 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
 
 interface TypeGuesser
 {
-    const TYPE_JPEG = 'jpeg';
-    const TYPE_PNG = 'png';
-    const TYPE_GIF = 'gif';
-    const TYPE_SVG = 'svg';
-    const TYPE_UNKNOWN = 'unknown';
+    public const TYPE_JPEG = 'jpeg';
+    public const TYPE_PNG = 'png';
+    public const TYPE_GIF = 'gif';
+    public const TYPE_SVG = 'svg';
+    public const TYPE_UNKNOWN = 'unknown';
 
     /**
      * @param string $filepath
      * @return string Image file type, value of one of the TYPE_* const
      */
     public function guess(string $filepath): string;
-} 
+}

--- a/src/ImageOptimizer/WrapperOptimizer.php
+++ b/src/ImageOptimizer/WrapperOptimizer.php
@@ -1,8 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
 
-interface WrapperOptimizer extends Optimizer {
+interface WrapperOptimizer extends Optimizer
+{
     public function unwrap(): Optimizer;
 }

--- a/tests/ImageOptimizer/Assertion/ImageAssertion.php
+++ b/tests/ImageOptimizer/Assertion/ImageAssertion.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\Assertion;
@@ -25,7 +26,7 @@ class ImageAssertion
     public function optimizedFileIsSmallerThanPercent(float $percent): ImageAssertion
     {
         $originalFilesize = filesize($this->originalImage);
-        $actualPercent = filesize($this->optimizedImage)/ $originalFilesize * 100;
+        $actualPercent = filesize($this->optimizedImage) / $originalFilesize * 100;
 
         Assert::assertLessThan($percent, $actualPercent, 'compression level is too small');
 
@@ -46,10 +47,10 @@ class ImageAssertion
     public function imagesAreSimilarInPercent(float $percent): ImageAssertion
     {
         $similarity = ImageSimilarityJudge::judge($this->originalImage, $this->optimizedImage);
-        $percent = $percent/100;
+        $percent = $percent / 100;
 
         Assert::assertGreaterThan($percent, $similarity);
 
         return $this;
     }
-} 
+}

--- a/tests/ImageOptimizer/CommandTest.php
+++ b/tests/ImageOptimizer/CommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
@@ -84,4 +85,4 @@ class CommandTest extends TestCase
 
         $this->assertSame(false, $exception);
     }
-} 
+}

--- a/tests/ImageOptimizer/ImageSimilarityJudge.php
+++ b/tests/ImageOptimizer/ImageSimilarityJudge.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
 
-use function imagecolorat;
-use function imagecolorsforindex;
 use ImageOptimizer\TypeGuesser\SmartTypeGuesser;
 use ImageOptimizer\TypeGuesser\TypeGuesser;
 use InvalidArgumentException;
@@ -24,7 +23,10 @@ class ImageSimilarityJudge
         $typeGuesser = new SmartTypeGuesser();
 
         // svg images are not supported, so judge the as identical
-        if($typeGuesser->guess($image1) === TypeGuesser::TYPE_SVG || $typeGuesser->guess($image2) === TypeGuesser::TYPE_SVG) {
+        if (
+            $typeGuesser->guess($image1) === TypeGuesser::TYPE_SVG ||
+            $typeGuesser->guess($image2) === TypeGuesser::TYPE_SVG
+        ) {
             return 1;
         }
 
@@ -35,8 +37,8 @@ class ImageSimilarityJudge
 
         $delta = 0;
 
-        for($x=0; $x<$width; $x++) {
-            for($y=0; $y<$height; $y++) {
+        for ($x = 0; $x < $width; $x++) {
+            for ($y = 0; $y < $height; $y++) {
                 //is faster about 30% than array_sum(array_map(...)) solution
                 $color1 = self::colorAt($resource1, $x, $y);
                 $color2 = self::colorAt($resource2, $x, $y);
@@ -46,7 +48,7 @@ class ImageSimilarityJudge
             }
         }
 
-        return 1 - ($width && $height ? $delta/(3*255*$width*$height) : 0);
+        return 1 - ($width && $height ? $delta / (3 * 255 * $width * $height) : 0);
     }
 
     private static function createResource(string $image)
@@ -54,9 +56,9 @@ class ImageSimilarityJudge
         $typeGuesser = new SmartTypeGuesser();
         $type = $typeGuesser->guess($image);
 
-        $function = 'imagecreatefrom'.$type;
+        $function = 'imagecreatefrom' . $type;
 
-        if(!function_exists($function)) {
+        if (!function_exists($function)) {
             throw new InvalidArgumentException(sprintf('Image "%s" is not supported', $type));
         }
 
@@ -68,4 +70,4 @@ class ImageSimilarityJudge
         $colorIndex = imagecolorat($image, $x, $y);
         return imagecolorsforindex($image, $colorIndex);
     }
-} 
+}

--- a/tests/ImageOptimizer/ImageSimilarityJudgeTest.php
+++ b/tests/ImageOptimizer/ImageSimilarityJudgeTest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
-
 
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +14,7 @@ class ImageSimilarityJudgeTest extends TestCase
      */
     public function testJudge(string $image1, string $image2, float $expectedGreaterThan, float $expectedLessThan = 1.)
     {
-        $actual = ImageSimilarityJudge::judge(__DIR__.'/Resources/'.$image1, __DIR__.'/Resources/'.$image2);
+        $actual = ImageSimilarityJudge::judge(__DIR__ . '/Resources/' . $image1, __DIR__ . '/Resources/' . $image2);
 
         $this->assertGreaterThanOrEqual($expectedGreaterThan, $actual);
         $this->assertLessThanOrEqual($expectedLessThan, $actual);
@@ -30,4 +30,3 @@ class ImageSimilarityJudgeTest extends TestCase
         ];
     }
 }
- 

--- a/tests/ImageOptimizer/OptimizersTest.php
+++ b/tests/ImageOptimizer/OptimizersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
@@ -9,14 +10,17 @@ use PHPUnit\Framework\TestCase;
 
 class OptimizersTest extends TestCase
 {
-    const TMP_DIR = 'tmp';
+    public const TMP_DIR = 'tmp';
 
     /**
      * @test
      * @dataProvider optimizerProvider
      */
-    public function givenOptimizerAndSampleFile_runOptimization_fileShouldBeSmallerAndTheSame(string $optimizerName, string $originalFile, float $expectedSizeOfOriginalFile = 70)
-    {
+    public function givenOptimizerAndSampleFile_runOptimization_fileShouldBeSmallerAndTheSame(
+        string $optimizerName,
+        string $originalFile,
+        float $expectedSizeOfOriginalFile = 70
+    ) {
         //given
 
         $factory = new OptimizerFactory([
@@ -51,11 +55,11 @@ class OptimizersTest extends TestCase
 
     public function optimizerProvider()
     {
-        $pngFile = __DIR__.'/Resources/sample.png';
-        $pngWithoutExtension = __DIR__.'/Resources/samplepng';
-        $gifFile = __DIR__.'/Resources/sample.gif';
-        $jpgFile = __DIR__.'/Resources/sample.jpg';
-        $svgFile = __DIR__.'/Resources/sample.svg';
+        $pngFile = __DIR__ . '/Resources/sample.png';
+        $pngWithoutExtension = __DIR__ . '/Resources/samplepng';
+        $gifFile = __DIR__ . '/Resources/sample.gif';
+        $jpgFile = __DIR__ . '/Resources/sample.jpg';
+        $svgFile = __DIR__ . '/Resources/sample.svg';
 
         return [
             ['optipng', $pngFile, 98.5],
@@ -86,7 +90,7 @@ class OptimizersTest extends TestCase
 
         $optimizer = $factory->get('png');
 
-        $optimizer->optimize(__DIR__.'/Resources/sample.jpg');
+        $optimizer->optimize(__DIR__ . '/Resources/sample.jpg');
     }
 
     /**
@@ -98,7 +102,7 @@ class OptimizersTest extends TestCase
 
         $optimizer = $factory->get('png');
 
-        $optimizer->optimize(__DIR__.'/Resources/sample.jpg');
+        $optimizer->optimize(__DIR__ . '/Resources/sample.jpg');
     }
 
     /**
@@ -110,11 +114,11 @@ class OptimizersTest extends TestCase
 
         $optimizer = $factory->get('jpg');
 
-        $sampleFile = $this->prepareSampleFile(__DIR__.'/Resources/sample.jpg');
+        $sampleFile = $this->prepareSampleFile(__DIR__ . '/Resources/sample.jpg');
 
         $optimizer->optimize($sampleFile);
 
-        ImageAssertion::create($sampleFile, __DIR__.'/Resources/'.self::TMP_DIR.'/sample-optimized.jpg')
+        ImageAssertion::create($sampleFile, __DIR__ . '/Resources/' . self::TMP_DIR . '/sample-optimized.jpg')
             ->imagesHaveTheSameDimensions()
             ->optimizedFileIsSmallerThanPercent(99)
             ->imagesAreSimilarInPercent(98.7)
@@ -141,29 +145,31 @@ class OptimizersTest extends TestCase
 
         $optimizer = $factory->get('jpg');
 
-        $sampleFile = $this->prepareSampleFile(__DIR__.'/Resources/sample.jpg');
+        $sampleFile = $this->prepareSampleFile(__DIR__ . '/Resources/sample.jpg');
 
         $optimizer->optimize($sampleFile);
 
-        $this->assertFileDoesNotExist(__DIR__.'/Resources/'.self::TMP_DIR.'/sample-optimized.jpg');
+        $this->assertFileDoesNotExist(__DIR__ . '/Resources/' . self::TMP_DIR . '/sample-optimized.jpg');
 
         // smart optimizer will delete the file if it fails
         $optimizer = $factory->get();
         $optimizer->optimize($sampleFile);
-        $this->assertFileDoesNotExist(__DIR__.'/Resources/'.self::TMP_DIR.'/sample-optimized.jpg');
+        $this->assertFileDoesNotExist(__DIR__ . '/Resources/' . self::TMP_DIR . '/sample-optimized.jpg');
     }
 
     protected function tearDown(): void
     {
-        foreach(['sample.gif', 'sample.jpg', 'sample.png', 'samplepng', 'sample.svg', 'sample-optimized.jpg'] as $file) {
-            @unlink(__DIR__.'/Resources/'.self::TMP_DIR.'/'.$file);
+        $files = ['sample.gif', 'sample.jpg', 'sample.png', 'samplepng', 'sample.svg', 'sample-optimized.jpg'];
+
+        foreach ($files as $file) {
+            @unlink(__DIR__ . '/Resources/' . self::TMP_DIR . '/' . $file);
         }
     }
 
     private function prepareSampleFile(string $originalFile)
     {
-        $destination = __DIR__.'/Resources/'.self::TMP_DIR.'/'.basename($originalFile);
-        if(!@copy($originalFile, $destination)) {
+        $destination = __DIR__ . '/Resources/' . self::TMP_DIR . '/' . basename($originalFile);
+        if (!@copy($originalFile, $destination)) {
             $this->fail(sprintf('Preparing sample file "%s" failed.', $originalFile));
         }
 

--- a/tests/ImageOptimizer/SmartOptimizerTest.php
+++ b/tests/ImageOptimizer/SmartOptimizerTest.php
@@ -1,19 +1,19 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer;
-
 
 use ImageOptimizer\TypeGuesser\TypeGuesser;
 use PHPUnit\Framework\TestCase;
 
 class SmartOptimizerTest extends TestCase
 {
-    const SUPPORTED_TYPE = 'png';
-    const UNSUPPORTED_TYPE = 'gif';
+    public const SUPPORTED_TYPE = 'png';
+    public const UNSUPPORTED_TYPE = 'gif';
 
-    const SUPPORTED_FILEPATH = 'somefilepath';
-    const UNSUPPORTED_FILEPATH = 'unsupportedFilepath';
+    public const SUPPORTED_FILEPATH = 'somefilepath';
+    public const UNSUPPORTED_FILEPATH = 'unsupportedFilepath';
 
     /**
      * @var SmartOptimizer
@@ -61,7 +61,7 @@ class SmartOptimizerTest extends TestCase
     public function givenUnsupportedFilepath_throwException()
     {
         $this->expectException(\ImageOptimizer\Exception\Exception::class);
-        
+
         //given
 
         $filepath = self::UNSUPPORTED_FILEPATH;

--- a/tests/ImageOptimizer/TypeGuesser/AbstractTypeGuesserTest.php
+++ b/tests/ImageOptimizer/TypeGuesser/AbstractTypeGuesserTest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
-
 
 use PHPUnit\Framework\TestCase;
 
@@ -30,9 +30,9 @@ abstract class AbstractTypeGuesserTest extends TestCase
     public function validImageFileProvider()
     {
         return [
-            [__DIR__.'/../Resources/sample.png', TypeGuesser::TYPE_PNG],
-            [__DIR__.'/../Resources/sample.jpg', TypeGuesser::TYPE_JPEG],
-            [__DIR__.'/../Resources/sample.gif', TypeGuesser::TYPE_GIF],
+            [__DIR__ . '/../Resources/sample.png', TypeGuesser::TYPE_PNG],
+            [__DIR__ . '/../Resources/sample.jpg', TypeGuesser::TYPE_JPEG],
+            [__DIR__ . '/../Resources/sample.gif', TypeGuesser::TYPE_GIF],
             [__FILE__, TypeGuesser::TYPE_UNKNOWN],
         ];
     }

--- a/tests/ImageOptimizer/TypeGuesser/ExtensionTypeGuesserTest.php
+++ b/tests/ImageOptimizer/TypeGuesser/ExtensionTypeGuesserTest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
-
 
 class ExtensionTypeGuesserTest extends AbstractTypeGuesserTest
 {
@@ -15,11 +15,10 @@ class ExtensionTypeGuesserTest extends AbstractTypeGuesserTest
     {
         $images = parent::validImageFileProvider();
         $images[] =  [
-            __DIR__.'/../Resources/sample.svg',
+            __DIR__ . '/../Resources/sample.svg',
             TypeGuesser::TYPE_SVG,
         ];
 
         return $images;
     }
 }
- 

--- a/tests/ImageOptimizer/TypeGuesser/GdTypeGuesserTest.php
+++ b/tests/ImageOptimizer/TypeGuesser/GdTypeGuesserTest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
-
 
 class GdTypeGuesserTest extends AbstractTypeGuesserTest
 {
@@ -15,4 +15,3 @@ class GdTypeGuesserTest extends AbstractTypeGuesserTest
         }
     }
 }
- 

--- a/tests/ImageOptimizer/TypeGuesser/SmartTypeGuesserTest.php
+++ b/tests/ImageOptimizer/TypeGuesser/SmartTypeGuesserTest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ImageOptimizer\TypeGuesser;
-
 
 class SmartTypeGuesserTest extends AbstractTypeGuesserTest
 {
@@ -15,11 +15,10 @@ class SmartTypeGuesserTest extends AbstractTypeGuesserTest
     {
         $images = parent::validImageFileProvider();
         $images[] =  [
-            __DIR__.'/../Resources/sample.svg',
+            __DIR__ . '/../Resources/sample.svg',
             TypeGuesser::TYPE_SVG,
         ];
 
         return $images;
     }
 }
- 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,6 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-$loader = require __DIR__.'/../vendor/autoload.php';
+$loader = require __DIR__ . '/../vendor/autoload.php';
 
-$loader->addPsr4('ImageOptimizer\\', __DIR__.'/ImageOptimizer');
+$loader->addPsr4('ImageOptimizer\\', __DIR__ . '/ImageOptimizer');


### PR DESCRIPTION
This PR makes your package compatible with [PSR-12 coding standards](https://www.php-fig.org/psr/psr-12/). It also adds a `composer phpcs` script for ease of use.

I had to add 3 rule exceptions in *.phpcs.xml* for stuff you have in your tests. I'd recommend these also be fixed and the exceptions removed.

i'd also suggest adding `composer phpcs` to .travis.yml so it's enforced on all future PRs.