### PR TITLE
Add method to check if optimizers are installed

### DIFF
--- a/src/ImageOptimizer/ChainOptimizer.php
+++ b/src/ImageOptimizer/ChainOptimizer.php
@@ -11,9 +11,9 @@ class ChainOptimizer implements Optimizer
     /**
      * @var Optimizer[]
      */
-    private $optimizers;
-    private $executeFirst;
-    private $logger;
+    public $optimizers;
+    public $executeFirst;
+    public $logger;
 
     public function __construct(array $optimizers, bool $executeFirst, LoggerInterface $logger)
     {

--- a/src/ImageOptimizer/Command.php
+++ b/src/ImageOptimizer/Command.php
@@ -11,9 +11,9 @@ use Symfony\Component\Process\Process;
 
 final class Command
 {
-    private $cmd;
-    private $args;
-    private $timeout;
+    public $cmd;
+    public $args;
+    public $timeout;
 
     public function __construct(string $bin, array $args = [], ?float $timeout = null)
     {

--- a/src/ImageOptimizer/CommandOptimizer.php
+++ b/src/ImageOptimizer/CommandOptimizer.php
@@ -6,8 +6,8 @@ namespace ImageOptimizer;
 
 class CommandOptimizer implements Optimizer
 {
-    private $command;
-    private $extraArgs;
+    public $command;
+    public $extraArgs;
 
     public function __construct(Command $command, $extraArgs = null)
     {


### PR DESCRIPTION
This PR adds a `checkOptimizers()` method that returns an array of all defined optimizers and whether or not they're installed. This is useful, for example, when displaying a configuration page explaining what needs to be installed for certain image types to compress correctly.

I had to make some private fields public for this to work.

Example usage:
```php
$factory = new \ImageOptimizer\OptimizerFactory();
print_r($factory->checkOptimizers());
```

```text
Array
(
    [/usr/local/bin/optipng] => true
    [/usr/local/bin/pngquant] => true
    [/usr/local/bin/pngcrush] => true
    [pngout] => false
    [/usr/local/bin/advpng] => true
    [/usr/local/bin/gifsicle] => true
    [/usr/local/bin/jpegoptim] => true
    [/usr/local/bin/jpegtran] => true
    [/usr/local/bin/svgo] => true
)
```