### PR TITLE
bug fix path in windows

### DIFF
--- a/src/ImageOptimizer/ChangedOutputOptimizer.php
+++ b/src/ImageOptimizer/ChangedOutputOptimizer.php
@@ -18,8 +18,8 @@ class ChangedOutputOptimizer implements WrapperOptimizer
     {
         $fileInfo = pathinfo($filepath);
         $outputFilepath = str_replace(
-            ['%basename%', '%filename%', '%ext%'],
-            [$fileInfo['dirname'], $fileInfo['filename'], isset($fileInfo['extension']) ? '.'.$fileInfo['extension'] : ''],
+            ['%basename%', '%filename%', '%ext%', '/'],
+            [$fileInfo['dirname'], $fileInfo['filename'], isset($fileInfo['extension']) ? '.'.$fileInfo['extension'] : '', '\\'],
             $this->outputPattern
         );
 


### PR DESCRIPTION
windows have different characters for the directory separator
when we run the optimizer on windows sometimes  $outputChanaged will be true
and the original image will be deleted